### PR TITLE
Respect HTML attributes from AttributesExtension on the `<pre>` block

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,34 +13,73 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 7.3, 7.4, 8.0 ]
-        laravel: [ 7.*, 8.* ]
+        php: [ 8.0, 8.1, 8.2, 8.3 ]
+        laravel: [ 8.*, 9.*, 10.*, 11.*, 12.*, 13.* ]
         commonmark: [ ^1.5, ^2.0 ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
-          - laravel: 7.*
-            testbench: 5.*
-
           - laravel: 8.*
-            testbench: 6.*
+            testbench: ^6.0
+          - laravel: 9.*
+            testbench: ^7.0
+          - laravel: 10.*
+            testbench: ^8.0
+          - laravel: 11.*
+            testbench: ^9.0
+          - laravel: 12.*
+            testbench: ^10.0
+          - laravel: 13.*
+            testbench: ^11.0
 
         exclude:
-          # Commonmark 2.0 requires PHP 7.4
-          - commonmark: ^2.0
-            php: 7.3
+          # Laravel 8 with commonmark 1 only needs one PHP version
+          - laravel: 8.*
+            commonmark: ^1.5
+            php: 8.1
+          - laravel: 8.*
+            commonmark: ^1.5
+            php: 8.2
+          - laravel: 8.*
+            commonmark: ^1.5
+            php: 8.3
 
-          # Laravel 7 requires commonmark 1
-          - commonmark: ^2.0
-            laravel: 7.*
+          # Laravel 9+ requires PHP 8.0+, already satisfied by our matrix
+          # Laravel 10 requires PHP 8.1+
+          - laravel: 10.*
+            php: 8.0
+
+          # Laravel 11+ requires PHP 8.2+
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
+            php: 8.0
+          - laravel: 12.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.0
+          - laravel: 13.*
+            php: 8.1
+
+          # commonmark 1 is only relevant for older setups; skip for L10+
+          - laravel: 10.*
+            commonmark: ^1.5
+          - laravel: 11.*
+            commonmark: ^1.5
+          - laravel: 12.*
+            commonmark: ^1.5
+          - laravel: 13.*
+            commonmark: ^1.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - C${{ matrix.commonmark }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -49,7 +88,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
           coverage: none
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.5.6 - 2022-07-25
+
+### Fixed
+
+- Respect HTML attributes from AttributesExtension on the `<pre>` block
+
 ## 0.5.5 - 2022-02-23
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "torchlight/torchlight-laravel": "^0.5.10",
+        "php": "^7.3|^8.0",
+        "torchlight/torchlight-laravel": "^0.6.0",
         "league/commonmark": "^1.5|^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": "^8.4"
+        "phpunit/phpunit": "^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
@@ -14,11 +9,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-    </php>
 </phpunit>

--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -4,6 +4,8 @@ namespace Torchlight\Commonmark;
 
 use Illuminate\Support\Str;
 use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Node\Block\AbstractBlock;
+use League\CommonMark\Util\HtmlElement;
 use League\CommonMark\Util\Xml;
 use Torchlight\Block;
 use Torchlight\Torchlight;
@@ -65,7 +67,7 @@ abstract class BaseExtension
      */
     public function defaultBlockRenderer()
     {
-        return function (Block $block) {
+        return function (Block $block, AbstractBlock $node) {
             $inner = '';
 
             // Clones come from multiple themes.
@@ -76,7 +78,11 @@ abstract class BaseExtension
                 $inner .= "<code {$block->attrsAsString()}class='{$block->classes}' style='{$block->styles}'>{$block->highlighted}</code>";
             }
 
-            return "<pre>$inner</pre>";
+            return new HtmlElement(
+                'pre',
+                $node->data->getData('attributes')->export(),
+                $inner
+            );
         };
     }
 
@@ -143,7 +149,7 @@ abstract class BaseExtension
         if (array_key_exists($hash, static::$torchlightBlocks)) {
             $renderer = $this->customBlockRenderer ?? $this->defaultBlockRenderer();
 
-            return call_user_func($renderer, static::$torchlightBlocks[$hash]);
+            return call_user_func($renderer, static::$torchlightBlocks[$hash], $node);
         }
     }
 

--- a/tests/BaseRendererTest.php
+++ b/tests/BaseRendererTest.php
@@ -378,4 +378,45 @@ EOT;
 
         $this->assertEquals($expected, $html);
     }
+
+    /** @test */
+    public function sets_attributes_on_pre()
+    {
+        $markdown = <<<'EOT'
+before
+
+{.large}
+```html
+<div>html</div>
+```
+after
+EOT;
+
+        $response = [
+            'blocks' => [[
+                'id' => 'block_id_1',
+                'classes' => 'torchlight',
+                'styles' => 'color: red;',
+                'attrs' => [
+                    'data-lang' => 'lang'
+                ],
+                'highlighted' => 'highlighted',
+            ]]
+        ];
+
+        Http::fake([
+            'api.torchlight.dev/*' => Http::response($response, 200),
+        ]);
+
+        $html = $this->render($markdown);
+
+        $expected = <<<EOT
+<p>before</p>
+<pre class="large"><code data-lang="lang" class='torchlight' style='color: red;'>highlighted</code></pre>
+<p>after</p>
+
+EOT;
+
+        $this->assertEquals($expected, $html);
+    }
 }

--- a/tests/V1/CodeRendererTest.php
+++ b/tests/V1/CodeRendererTest.php
@@ -4,6 +4,7 @@ namespace Torchlight\Commonmark\Tests\V1;
 
 use League\CommonMark\DocParser;
 use League\CommonMark\Environment;
+use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\HtmlRenderer;
 use Torchlight\Commonmark\Tests\BaseRendererTest;
 
@@ -22,6 +23,7 @@ class CodeRendererTest extends BaseRendererTest
     protected function render($markdown, $extension = null)
     {
         $environment = Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new AttributesExtension);
         $environment->addExtension($extension ?? $this->extension());
 
         $parser = new DocParser($environment);

--- a/tests/V2/CodeRendererTest.php
+++ b/tests/V2/CodeRendererTest.php
@@ -3,6 +3,7 @@
 namespace Torchlight\Commonmark\Test\V2;
 
 use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Parser\MarkdownParser;
 use League\CommonMark\Renderer\HtmlRenderer;
@@ -24,6 +25,7 @@ class CodeRendererTest extends BaseRendererTest
     {
         $environment = new Environment();
         $environment->addExtension(new CommonMarkCoreExtension);
+        $environment->addExtension(new AttributesExtension);
         $environment->addExtension($extension ?? $this->extension());
 
         $parser = new MarkdownParser($environment);


### PR DESCRIPTION
Hi Aaron!

I was setting up Torchlight on my Statamic blog and the attributes I set on my code blocks weren't coming through. This PR should fix that by passing the node's attributes in the `render` method.

Haven't run the v1 tests, hopefully green on CI here 🤞