### PR TITLE
add support for torchlight v0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "torchlight/torchlight-laravel": "^0.5.10",
+        "torchlight/torchlight-laravel": "^0.6.0",
         "league/commonmark": "^1.5|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
updating the constrain for `torchlight` to add support for torchlight v0.6
