### PR TITLE
Bump dep for torchlight-laravel to "^0.6.1 to support Laravel 12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.6.0 - 2022-02-23
+
+### Changed
+
+- Updated torchlight-laravel version constraint
+
 ## 0.5.5 - 2022-02-23
 
 ### Changed
@@ -50,7 +56,6 @@
 - Bump `torchlight/torchlight-laravel` dependency.
 - Use `Torchlight::highlight` instead of `(new Client)->highlight`
 
-
 ## 0.3.3 - 2021-07-31
 
 ### Changed
@@ -80,7 +85,6 @@
 
 - Bump `torchlight/torchlight-laravel` dependency.
 - Changed package name from `torchlight/commonmark` to `torchlight/torchlight-commonmark`
-
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-## Unreleased
-
-## 0.6.0 - 2022-02-23
+## 0.5.6 - Unreleased
 
 ### Changed
 
-- Updated torchlight-laravel version constraint
+- Updated torchlight-laravel version constraint to support Laravel 12.x
 
 ## 0.5.5 - 2022-02-23
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "torchlight/torchlight-laravel": "^0.5.10",
+        "torchlight/torchlight-laravel": "^0.6.0",
         "league/commonmark": "^1.5|^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "torchlight/torchlight-laravel": "^0.6.0",
+        "torchlight/torchlight-laravel": "^v0.6.1",
         "league/commonmark": "^1.5|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request updates the `torchlight-laravel` dependency to support Laravel 12.x and reflects this change in the `CHANGELOG.md` and `composer.json` files.

### Dependency Updates:
* Updated the `torchlight/torchlight-laravel` version constraint in `composer.json` to `^v0.6.1` to support Laravel 12.x.

### Documentation Updates:
* Updated the `CHANGELOG.md` to reflect the new version `0.5.6 - Unreleased` and document the updated `torchlight-laravel` version constraint.